### PR TITLE
feat: 使用 configure 进行全局配置

### DIFF
--- a/packages/icons-react-taro/src/IconFont.tsx
+++ b/packages/icons-react-taro/src/IconFont.tsx
@@ -1,4 +1,5 @@
 import React, {FunctionComponent, ReactHTML} from 'react'
+import {globalConfig} from "./internal";
 
 export interface IconFontProps {
     name?: string
@@ -20,10 +21,7 @@ const defaultProps = {
     size: '',
     width: '',
     height: '',
-    classPrefix: 'nut-icon',
-    fontClassName: 'nutui-iconfont',
     color: '',
-    tag: 'i',
     onClick: (e: MouseEvent) => {
     },
     className: '',
@@ -37,12 +35,12 @@ const Icon: FunctionComponent<IconFontProps> = (props: IconFontProps) => {
     const {
         name,
         size,
-        classPrefix,
+        classPrefix = globalConfig.classPrefix,
         color,
-        tag,
+        tag = globalConfig.tag,
         children,
         className,
-        fontClassName,
+        fontClassName= globalConfig.fontClassName,
         style,
         onClick,
         ...rest
@@ -67,8 +65,8 @@ const Icon: FunctionComponent<IconFontProps> = (props: IconFontProps) => {
         type,
         {
             className: isImage
-                ? `nut-icon-img ${className || ''} `
-                : `${fontClassName} nut-icon ${classPrefix}-${name} ${
+                ? `${classPrefix}-img ${className || ''} `
+                : `${fontClassName} ${classPrefix} ${classPrefix}-${name} ${
                     className || ''
                 }`,
             style: {

--- a/packages/icons-react-taro/src/IconTemplate.tsx
+++ b/packages/icons-react-taro/src/IconTemplate.tsx
@@ -1,4 +1,5 @@
-import {FunctionComponent} from "react";
+import React, {FunctionComponent} from "react";
+import {globalConfig} from "./internal";
 
 export interface SVG_IconProps {
     className?: string
@@ -12,6 +13,7 @@ export interface SVG_IconProps {
     svg64?: string
     onClick?: (event: React.MouseEvent) => void
     children?: React.ReactNode
+    fallback?: boolean
 }
 
 export const defaultProps = {
@@ -26,41 +28,56 @@ export const defaultProps = {
 } as SVG_IconProps
 
 const Icon: FunctionComponent<SVG_IconProps> = (props: SVG_IconProps) => {
-    const { className, style, name, color, width, height, size, svg64, onClick} = {...defaultProps, ...props}
+    const classPrefix = globalConfig.classPrefix
+    const {
+        className,
+        style,
+        name,
+        color,
+        width,
+        height,
+        size,
+        svg64,
+        onClick,
+        fallback = globalConfig.useSvg
+    } = {...defaultProps, ...props}
     const handleClick: React.MouseEventHandler = (e) => {
         onClick && onClick(e)
     }
     const pxCheck = (value: string | number): string => {
-        if(value === '') return ''
+        if (value === '') return ''
         return isNaN(Number(value)) ? String(value) : value + "px";
     };
     const classes = () => {
-        return `nut-icon nut-icon-${name} ${className}`
+        const iconName = fallback ? name?.toLowerCase() : name
+        return `${fallback ? globalConfig.fontClassName : ''} ${classPrefix} ${classPrefix}-${iconName} ${className}`
     };
-    const props2Style:any = {}
+    const props2Style: any = {}
     const checkedWidth = pxCheck(width || size || '')
     const checkedHeight = pxCheck(height || size || '')
-    if(checkedWidth) {
+    if (checkedWidth) {
         props2Style['width'] = checkedWidth
     }
-    if(checkedHeight) {
+    if (checkedHeight) {
         props2Style['height'] = checkedHeight
     }
     const getStyle = () => {
         return {
             ...style,
-            backgroundColor: color|| 'currentColor',
-            mask: `url('${svg64}')  0 0/100% 100% no-repeat`,
-            '-webkitMask': `url('${svg64}') 0 0/100% 100% no-repeat`,
+            ...(fallback ? {} : {
+                backgroundColor: color || 'currentColor',
+                mask: `url('${svg64}')  0 0/100% 100% no-repeat`,
+                '-webkitMask': `url('${svg64}') 0 0/100% 100% no-repeat`,
+            }),
             ...props2Style
         }
     }
-    return <span
-            className={classes()}
-            style={getStyle()}
-            onClick={handleClick}
-            color={color}
-        >{props.children}</span>
+    return React.createElement<any>(globalConfig.tag, {
+        className: classes(),
+        style: getStyle(),
+        onClick: handleClick,
+        color
+    }, props.children)
 }
 Icon.defaultProps = defaultProps
 export default Icon

--- a/packages/icons-react-taro/src/buildEntry/lib-new-dts.ts
+++ b/packages/icons-react-taro/src/buildEntry/lib-new-dts.ts
@@ -1,6 +1,7 @@
 /** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
-    export { IconFont  };
+    import { configure } from "../configure";
+    export { IconFont, configure  };
 
 export { default as AddCircle } from "../components/AddCircle";
 export { default as AddRectangle } from "../components/AddRectangle";

--- a/packages/icons-react-taro/src/buildEntry/lib-new.ts
+++ b/packages/icons-react-taro/src/buildEntry/lib-new.ts
@@ -1,7 +1,8 @@
 /** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
+    import { configure } from "../configure";
     import config from '../../../../iconfont/config.json';
-    export { IconFont, config };
+    export { IconFont, config, configure };
 
 export { default as AddCircle }  from '../components/AddCircle'
 export { default as AddRectangle }  from '../components/AddRectangle'

--- a/packages/icons-react-taro/src/configure.ts
+++ b/packages/icons-react-taro/src/configure.ts
@@ -1,0 +1,13 @@
+import {Configure, ConfigureKey, globalConfig} from "./internal";
+
+export function configure(config: Configure) {
+    if (typeof config === 'object' && config !== null) {
+        let key: ConfigureKey
+        for (key in config) {
+            if (config.hasOwnProperty(key) && config[key]) {
+                // @ts-ignore
+                globalConfig[key] = config[key]
+            }
+        }
+    }
+}

--- a/packages/icons-react-taro/src/internal.ts
+++ b/packages/icons-react-taro/src/internal.ts
@@ -1,0 +1,13 @@
+export type Configure = {
+    useSvg?: boolean
+    classPrefix?: string
+    tag?: string
+    fontClassName?: string
+}
+export type ConfigureKey = keyof Configure
+export const globalConfig = {
+    useSvg: true,
+    classPrefix: 'nut-icon',
+    tag: 'i',
+    fontClassName: 'nutui-iconfont'
+}

--- a/packages/icons-react-taro/vite.config.build.es.ts
+++ b/packages/icons-react-taro/vite.config.build.es.ts
@@ -5,6 +5,8 @@ import {iconsConfig} from './src/components/iconsConfig'
 
 let input = {
   IconFont: `./src/IconFont.tsx`,
+  configure: `./src/configure.ts`,
+  internal: `./src/internal.ts`,
   IconFontConfig: `./src/buildEntry/iconFontConfig.ts`,
   SvgConfig: `./src/buildEntry/svgConfig.ts`,
 } as any;
@@ -24,9 +26,14 @@ export default defineConfig({
     },
     rollupOptions: {
       // 确保外部化处理那些你不想打包进库的依赖
-      external: ['react', 'react-dom', 'classnames'],
+      external: ['react', 'react-dom', 'classnames', './internal', './configure'],
       // input,
       output: {
+        paths: (id) => {
+          return /internal/.test(id)
+              ? `./internal.js`
+              : id
+        },
         entryFileNames: '[name].js',
         dir: resolve(__dirname, './dist/es/icons'),
         // 在 UMD 构建模式下为这些外部化的依赖提供一个全局变量

--- a/packages/icons-react/src/IconFont.tsx
+++ b/packages/icons-react/src/IconFont.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactHTML } from 'react'
+import {globalConfig} from "./internal";
 
 export interface IconProps {
     name: string
@@ -16,10 +17,7 @@ export interface IconProps {
 const defaultProps = {
     name: '',
     size: '',
-    classPrefix: 'nut-icon',
-    fontClassName: 'nutui-iconfont',
     color: '',
-    tag: 'i',
     onClick: (e: MouseEvent) => {},
     className: '',
 } as IconProps
@@ -32,12 +30,12 @@ export default function Icon<T>(props: Partial<IconProps> & T): ReactElement {
     const {
         name,
         size,
-        classPrefix,
+        classPrefix = globalConfig.classPrefix,
         color,
-        tag,
+        tag= globalConfig.tag,
         children,
         className,
-        fontClassName,
+        fontClassName= globalConfig.fontClassName,
         style,
         onClick,
         ...rest
@@ -61,8 +59,8 @@ export default function Icon<T>(props: Partial<IconProps> & T): ReactElement {
         type,
         {
             className: isImage
-                ? `nut-icon__img ${className || ''} `
-                : `${fontClassName} nut-icon ${classPrefix}-${name} ${
+                ? `${classPrefix}__img ${className || ''} `
+                : `${fontClassName} ${classPrefix} ${classPrefix}-${name} ${
                     className || ''
                 }`,
             style: {

--- a/packages/icons-react/src/IconTemplate.tsx
+++ b/packages/icons-react/src/IconTemplate.tsx
@@ -1,4 +1,5 @@
 import {FunctionComponent} from "react";
+import {globalConfig} from "./internal";
 
 export interface SVG_IconProps {
     className?: string
@@ -23,6 +24,7 @@ export const defaultProps = {
 } as SVG_IconProps
 
 const Icon: FunctionComponent<SVG_IconProps> = (props: SVG_IconProps) => {
+    const classPrefix = globalConfig.classPrefix
     const {viewBox, className, style, name, color, width, height, onClick} = {...defaultProps, ...props}
     const handleClick: React.MouseEventHandler = (e) => {
         onClick && onClick(e)
@@ -32,7 +34,7 @@ const Icon: FunctionComponent<SVG_IconProps> = (props: SVG_IconProps) => {
         return isNaN(Number(value)) ? String(value) : value + "px";
     };
     const classes = () => {
-        return `nut-icon nut-icon-${name} ${className}`
+        return `${classPrefix} ${classPrefix}-${name} ${className}`
     };
     const props2Style:any = {}
     const checkedWidth = pxCheck(width || '')

--- a/packages/icons-react/src/buildEntry/lib-new-dts.ts
+++ b/packages/icons-react/src/buildEntry/lib-new-dts.ts
@@ -1,6 +1,7 @@
 /** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
-    export { IconFont  };
+    import { configure } from "../configure";
+    export { IconFont, configure  };
 
 export { default as AddCircle } from "../components/AddCircle";
 export { default as AddRectangle } from "../components/AddRectangle";

--- a/packages/icons-react/src/buildEntry/lib-new.ts
+++ b/packages/icons-react/src/buildEntry/lib-new.ts
@@ -1,7 +1,8 @@
 /** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
+    import { configure } from "../configure";
     import config from '../../../../iconfont/config.json';
-    export { IconFont, config };
+    export { IconFont, config, configure };
 
 export { default as AddCircle }  from '../components/AddCircle'
 export { default as AddRectangle }  from '../components/AddRectangle'

--- a/packages/icons-react/src/configure.ts
+++ b/packages/icons-react/src/configure.ts
@@ -1,0 +1,13 @@
+import {Configure, ConfigureKey, globalConfig} from "./internal";
+
+export function configure(config: Configure) {
+    if (typeof config === 'object' && config !== null) {
+        let key: ConfigureKey
+        for (key in config) {
+            if (config.hasOwnProperty(key) && config[key]) {
+                // @ts-ignore
+                globalConfig[key] = config[key]
+            }
+        }
+    }
+}

--- a/packages/icons-react/src/internal.ts
+++ b/packages/icons-react/src/internal.ts
@@ -1,0 +1,11 @@
+export type Configure = {
+    classPrefix?: string
+    tag?: string
+    fontClassName?: string
+}
+export type ConfigureKey = keyof Configure
+export const globalConfig = {
+    classPrefix: 'nut-icon',
+    tag: 'i',
+    fontClassName: 'nutui-iconfont'
+}

--- a/packages/icons-react/vite.config.build.es.ts
+++ b/packages/icons-react/vite.config.build.es.ts
@@ -5,6 +5,8 @@ import {iconsConfig} from './src/components/iconsConfig'
 
 let input = {
   IconFont: `./src/IconFont.tsx`,
+  configure: `./src/configure.ts`,
+  internal: `./src/internal.ts`,
   IconFontConfig: `./src/buildEntry/iconFontConfig.ts`,
   SvgConfig: `./src/buildEntry/svgConfig.ts`,
 } as any;
@@ -24,9 +26,14 @@ export default defineConfig({
     },
     rollupOptions: {
       // 确保外部化处理那些你不想打包进库的依赖
-      external: ['react', 'react-dom', 'classnames'],
+      external: ['react', 'react-dom', 'classnames', './internal', './configure'],
       // input,
       output: {
+        paths: (id) => {
+          return /internal/.test(id)
+              ? `./internal.js`
+              : id
+        },
         entryFileNames: '[name].js',
         dir: resolve(__dirname, './dist/es/icons'),
         // 在 UMD 构建模式下为这些外部化的依赖提供一个全局变量

--- a/scripts/generate-react.ts
+++ b/scripts/generate-react.ts
@@ -63,16 +63,19 @@ export default IconSVG
 let entryEs = `/** 此文件由 script generate 脚本生成 */
 export { config as IconFontConfig } from "./icons/IconFontConfig.js";
 export { default as IconFont } from "./icons/IconFont.js";
+export { configure } from "./icons/configure.js";
 \n`;
 
 let entryLib = `/** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
+    import { configure } from "../configure";
     import config from '../../../../iconfont/config.json';
-    export { IconFont, config };
+    export { IconFont, config, configure };
 \n`;
 let entryLibDTS = `/** 此文件由 script generate 脚本生成 */
     import IconFont from '../IconFont';
-    export { IconFont  };
+    import { configure } from "../configure";
+    export { IconFont, configure  };
 \n`;
 
 const pattern = `${process.cwd()}/packages/icons-svg/*.svg`;


### PR DESCRIPTION
为什么需要 configure 方法？

1.在 taro 包的实现中采用了 CSS Mask 支持 SVG，但是由于 CSS Mask 存在兼容问题，比如需要在 15.4 的 iOS 设备上才能正常展示。
基于之前的实现，给到开发者的解决方案是通过安装之前的 Icon 包，或者使用现在的 IconFont 组件进行替换。这一替换的成本比较高，主要有以下原因：其一，组件是否支持 Icon 扩展，如果不支持则继续展示错误 Icon，其二，开发者需要设置每个需要更换Icon的组件。

基于上述原因，所以提供了 configure 来实现兼容回退的情况。

具体使用方式：

```
import { configure, Add } from "@nutui/icons-react-taro";

configure({
	useSvg: false,
})
```
通过设置 useSvg 为 false，开启 iconfont 的模式。